### PR TITLE
Allow any entities to be added to card

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { HassEntity } from "./types";
+import { ControlType, HassEntity } from "./types";
 
 export type EntitiesFunc = (predicate: (id: string) => boolean) => HassEntity[];
 
@@ -12,7 +12,17 @@ const STOPPABLE_STATES = [...ACTIVE_STATES, ...WAITING_STATES]
 export const isStation    = (id: string) => id.startsWith('sensor.') && id.endsWith('_status');
 export const isProgram    = (id: string) => id.startsWith('binary_sensor.') && id.endsWith('_program_running');
 export const isController = (id: string) => id.startsWith('switch.') && id.endsWith('opensprinkler_enabled');
+export const isRunOnce = (id: string) => id === 'run_once';
 export const isStationProgEnable = (id: string) => id.startsWith('switch.') && id.endsWith('_enabled');
+
+export const getControlType = (id: string) => {
+    switch (true) {
+        case isStation(id): return ControlType.Station;
+        case isProgram(id): return ControlType.Program;
+        case isRunOnce(id): return ControlType.RunOnce;
+        default: return ControlType.State;
+    }
+}
 
 export function hasRunOnce(entities: EntitiesFunc) {
     return entities(isStation).some(e => e.attributes.running_program_id === RUN_ONCE_ID);

--- a/src/opensprinkler-card.ts
+++ b/src/opensprinkler-card.ts
@@ -6,13 +6,13 @@ import { UnsubscribeFunc } from 'home-assistant-js-websocket';
 
 import { fillConfig, TimerBarEntityRow } from 'lovelace-timer-bar-card/src/timer-bar-entity-row';
 import { EntityRegistryEntry, subscribeEntityRegistry } from './ha_entity_registry';
-import type { OpensprinklerCardConfig, HassEntity } from './types';
+import { OpensprinklerCardConfig, HassEntity, ControlType } from './types';
 import "./editor";
 import "./opensprinkler-generic-entity-row";
 import "./opensprinkler-more-info-dialog";
 import "./opensprinkler-control";
 import { MoreInfoDialog } from './opensprinkler-more-info-dialog';
-import { EntitiesFunc, hasManual, hasRunOnce, isProgram, isStation, osName, stateActivated, stateWaiting } from './helpers';
+import { EntitiesFunc, getControlType, hasManual, hasRunOnce, isProgram, isStation, osName, stateActivated, stateWaiting } from './helpers';
 import { renderState } from './opensprinkler-state';
 
 // This puts your card into the UI card picker dialog
@@ -165,7 +165,8 @@ export class OpensprinklerCard extends LitElement {
   private _renderCardStations() {
     if (!this.config.card_stations) return '';
     return this.config.card_stations.map(e => {
-      return html`<opensprinkler-control type="station" .entity=${this.hass!.states[e]}
+      if (getControlType(e) === ControlType.State) return renderState(e, this.hass!);
+      return html`<opensprinkler-control .entity=${this.hass!.states[e]}
                    .entities=${p => this._matchingEntities(p)} .hass=${this.hass}
                    .input_number=${this.config.input_number?.entity}
                 ></opensprinkler-control>`;

--- a/src/opensprinkler-more-info-dialog.ts
+++ b/src/opensprinkler-more-info-dialog.ts
@@ -86,8 +86,8 @@ export class MoreInfoDialog extends LitElement {
     return renderState(entity.entity_id, this.hass, (e:CustomEvent) => this._moreInfo(e));
   }
 
-  private _renderControl(type: ControlType, entity: HassEntity) {
-    return html`<opensprinkler-control type=${type} .entity=${entity}
+  private _renderControl(entity: HassEntity) {
+    return html`<opensprinkler-control .entity=${entity}
                    .entities=${this.entities} .hass=${this.hass}
                    .input_number=${this._config!.input_number?.entity}
                    @hass-more-info=${this._moreInfo}
@@ -110,14 +110,14 @@ export class MoreInfoDialog extends LitElement {
       this._config!.input_number ? renderState(this._config!.input_number, this.hass) : '',
     ]
     .concat(this.entities(isStation).filter(s => this._shouldShowStation(s)).map(s => {
-      return this._renderControl(ControlType.Station, s);
+      return this._renderControl(s);
     }))
     .concat([
       this._renderHeading('Programs'),
-      hasRunOnce(this.entities) ? this._renderControl(ControlType.RunOnce, runOnceEntity) : html``,
+      hasRunOnce(this.entities) ? this._renderControl(runOnceEntity) : html``,
     ])
     .concat(this.entities(isProgram).map(s => {
-      return this._renderControl(ControlType.Program, s);
+      return this._renderControl(s);
     }));
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,8 @@ import { TimerBarConfig } from 'lovelace-timer-bar-card/src/types';
 export enum ControlType {
   Station = "station",
   Program = "program",
-  RunOnce = "run-once"
+  RunOnce = "run-once",
+  State = "state"
 };
 
 export declare type HassEntity = {


### PR DESCRIPTION
Not sure how you feel about this but this PR makes it able to show more than just stations. At first I only wanted to show the water level and programs but I realized after doing it any entity would work too, even ones that don't belong to the device. As you can see from the screenshot below I added a light and a motion sensor just for testing.

![image](https://user-images.githubusercontent.com/819711/123384894-4871c580-d5d8-11eb-804c-1e4c1d66361e.png)

In this case maybe the config `card_stations` should be renamed too?
