### PR TITLE
Show Rain Delay Stop Time if rain delay is active

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Otherwise, make sure:
 - The ids of program running binary sensors end with `_running`
 - The id of the OpenSprinkler controller enabled switch ends with `_enabled`
 - The ids of program & station enabled switches end with `_enabled`
+- The id of the rain delay active binary sensor ends with `_rain_delay_active`
+- The id of the rain delay stop time sensor ends with `_rain_delay_stop_time`
 
 ## Extra entities and duration control
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@mdi/js": "^6.5.95",
-    "custom-card-helpers": "^1.8.0",
-    "home-assistant-js-websocket": "^5.12.0",
+    "custom-card-helpers": "^1.9.0",
+    "home-assistant-js-websocket": "^6.0.1",
     "lit": "^2.0.2",
     "lovelace-timer-bar-card": "^1.15.0"
   },

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
   "repository": "git@github.com:rianadon/opensprinkler-card.git",
   "license": "Apache-2.0",
   "dependencies": {
+    "@formatjs/intl-utils": "^3.8.4",
     "@mdi/js": "^6.5.95",
-    "custom-card-helpers": "^1.9.0",
-    "home-assistant-js-websocket": "^6.0.1",
+    "custom-card-helpers": "1.8.0",
+    "home-assistant-js-websocket": "^5.12.0",
     "lit": "^2.0.2",
     "lovelace-timer-bar-card": "^1.15.0"
   },

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,12 +25,21 @@ export const isStationProgEnable = (entity: HassEntity) =>
     entity.entity_id.startsWith('switch.');
 export const isPlayPausable = (entity: HassEntity) =>
     isStation(entity) || isProgram(entity) || isRunOnce(entity)
+export const isRainDelayActiveSensor = (entity: HassEntity) =>
+    entity.entity_id.startsWith('binary_sensor.') &&
+    entity.entity_id.endsWith('rain_delay_active')
+export const isRainDelayStopTime = (entity: HassEntity) =>
+    entity.entity_id.startsWith('sensor.') &&
+    entity.entity_id.endsWith('rain_delay_stop_time')
 
 export function hasRunOnce(entities: EntitiesFunc) {
     return entities(isStation).some(e => e.attributes.running_program_id === RUN_ONCE_ID);
 }
 export function hasManual(entities: EntitiesFunc) {
     return entities(isStation).some(e => e.attributes.running_program_id === MANUAL_ID);
+}
+export function hasRainDelayActive(entities: EntitiesFunc) {
+    return entities(isRainDelayActiveSensor).some(e => e.state === 'on');
 }
 
 export const stateWaiting   = (entity: HassEntity) => WAITING_STATES.includes(entity.state);

--- a/src/opensprinkler-card.ts
+++ b/src/opensprinkler-card.ts
@@ -1,6 +1,6 @@
 import { LitElement, css, html, TemplateResult } from 'lit';
 import { customElement, state, property } from "lit/decorators";
-import { HomeAssistant, LovelaceCardEditor } from 'custom-card-helpers';
+import { HomeAssistant, LovelaceCardEditor, relativeTime } from 'custom-card-helpers';
 import { PropertyValues } from 'lit-element';
 import { UnsubscribeFunc } from 'home-assistant-js-websocket';
 
@@ -13,7 +13,7 @@ import "./opensprinkler-generic-entity-row";
 import "./opensprinkler-more-info-dialog";
 import "./opensprinkler-control";
 import { MoreInfoDialog } from './opensprinkler-more-info-dialog';
-import { EntitiesFunc, hasManual, hasRunOnce, isPlayPausable, isProgram, isStation, lineHeight, osName, stateActivated, stateWaiting } from './helpers';
+import { EntitiesFunc, hasManual, hasRainDelayActive, hasRunOnce, isPlayPausable, isProgram, isRainDelayStopTime, isStation, lineHeight, osName, stateActivated, stateWaiting } from './helpers';
 import { renderState } from './opensprinkler-state';
 import { styleMap } from 'lit/directives/style-map';
 
@@ -208,6 +208,11 @@ export class OpensprinklerCard extends LitElement {
 
   private _secondaryText() {
     const entities: EntitiesFunc = p => this._matchingEntities(p)
+
+    if (hasRainDelayActive(entities)) {
+      const stop_time = entities(isRainDelayStopTime).find(_ => true)?.state;
+      return `Rain delay${ stop_time ? ` ends ${relativeTime(new Date(stop_time), this.hass!.locale)}` : ''}`;
+    }
 
     const programs = entities(isProgram).filter(stateActivated).map(osName);
     if (hasRunOnce(entities)) programs.splice(0, 0, 'Once Program');

--- a/src/opensprinkler-card.ts
+++ b/src/opensprinkler-card.ts
@@ -1,6 +1,6 @@
 import { LitElement, css, html, TemplateResult } from 'lit';
 import { customElement, state, property } from "lit/decorators";
-import { HomeAssistant, LovelaceCardEditor, relativeTime } from 'custom-card-helpers';
+import { HomeAssistant, LovelaceCardEditor } from 'custom-card-helpers';
 import { PropertyValues } from 'lit-element';
 import { UnsubscribeFunc } from 'home-assistant-js-websocket';
 
@@ -16,6 +16,7 @@ import { MoreInfoDialog } from './opensprinkler-more-info-dialog';
 import { EntitiesFunc, hasManual, hasRainDelayActive, hasRunOnce, isPlayPausable, isProgram, isRainDelayStopTime, isStation, lineHeight, osName, stateActivated, stateWaiting } from './helpers';
 import { renderState } from './opensprinkler-state';
 import { styleMap } from 'lit/directives/style-map';
+import { relativeTime } from './relative_time';
 
 // This puts your card into the UI card picker dialog
 (window as any).customCards = (window as any).customCards || [];
@@ -211,7 +212,7 @@ export class OpensprinklerCard extends LitElement {
 
     if (hasRainDelayActive(entities)) {
       const stop_time = entities(isRainDelayStopTime).find(_ => true)?.state;
-      return `Rain delay${ stop_time ? ` ends ${relativeTime(new Date(stop_time), this.hass!.locale)}` : ''}`;
+      return `Rain delay${ stop_time ? ` ends ${relativeTime(new Date(stop_time), this.hass!.locale!)}` : ''}`;
     }
 
     const programs = entities(isProgram).filter(stateActivated).map(osName);

--- a/src/relative_time.ts
+++ b/src/relative_time.ts
@@ -1,0 +1,52 @@
+//REF: https://github.com/custom-cards/custom-card-helpers/blob/master/src/datetime/relative_time.ts
+//REF: https://github.com/home-assistant/frontend/blob/dev/src/common/datetime/relative_time.ts
+
+import { selectUnit } from "@formatjs/intl-utils";
+
+// REF: https://github.com/custom-cards/custom-card-helpers/blob/master/src/types.ts
+// REF: https://github.com/home-assistant/frontend/blob/dev/src/data/translation.ts
+enum NumberFormat {
+    language = "language",
+    system = "system",
+    comma_decimal = "comma_decimal",
+    decimal_comma = "decimal_comma",
+    space_comma = "space_comma",
+    none = "none",
+}
+
+export enum TimeFormat {
+    language = "language",
+    system = "system",
+    am_pm = "12",
+    twenty_four = "24",
+}
+
+interface MinBarFrontendLocaleData {
+    language: string;
+}
+
+ const formatRelTimeMem =
+  (locale: MinBarFrontendLocaleData) =>
+    new Intl.RelativeTimeFormat(locale.language, { numeric: "auto" });
+
+/**
+ * Calculate a string representing a date object as relative time from now.
+ *
+ * Example output: 5 minutes ago, in 3 days.
+ */
+ export const relativeTime = (
+  from: Date,
+  locale: MinBarFrontendLocaleData,
+  to?: Date,
+  includeTense = true
+): string => {
+  const diff = selectUnit(from, to);
+  if (includeTense) {
+    return formatRelTimeMem(locale).format(diff.value, diff.unit);
+  }
+  return Intl.NumberFormat(locale.language, {
+    style: "unit",
+    unit: diff.unit,
+    unitDisplay: "long",
+  }).format(Math.abs(diff.value));
+};


### PR DESCRIPTION
Implements #16 

In this PR:
- Find the rain delay active binary sensor to check whether currently under rain delay
- Fetch the rain delay stop time sensor value and format as relative time into the secondary text
- Use `relativeTime` formatting from `custom-card-helpers` (off-the-shelf clone of the HA frontend implementation)
- Update `custom-card-helpers` dependency for current `relativeTime` implementation, and in turn update its dependency `home-assistant-js-websocket`.

Net Result:
2 hour rain delay:
![image](https://user-images.githubusercontent.com/1765921/171553990-2b3a704b-fa4a-476b-9c11-943d9139db89.png)
28 hour rain delay:
![image](https://user-images.githubusercontent.com/1765921/171554249-e68490ab-ca43-4ce5-b017-68c380a0e55c.png)

**Note:** proper functionality here is dependent on a bugfix from the HACS opensprinkler integration being published, which corrects an issue on the integration side where the rain delay stop time was not being properly converted from local time to UTC. That fix is now merged and on its way through the release process, but without it the reported rain delay times may be surprising 😄 

TODO:
- [x] ~Verify that the upgrade of `home-assistant-js-websocket` is OK~
    - ~Usage: `Connection, createCollection` in `ha_entity_registry.ts`, `UnsubscribeFunc` in `opensprinkler-cards.ts`~
- [x] Wait for the updated HACS integration to be released so that this is easier to validate end to end
    - Released as 1.1.10