### PR TITLE
Fix NotFoundError in disconnectedCallback

### DIFF
--- a/src/opensprinkler-card.ts
+++ b/src/opensprinkler-card.ts
@@ -151,11 +151,16 @@ export class OpensprinklerCard extends LitElement {
 
   public disconnectedCallback() {
     super.disconnectedCallback();
-    if (this.unsub) this.unsub();
-    this.unsub = undefined;
-    document.body.removeChild(this.dialog);
+    if (this.unsub) {
+      this.unsub();
+      this.unsub = undefined;
+    }
+    
+    if (this.dialog && this.dialog.parentNode) {
+      this.dialog.parentNode.removeChild(this.dialog);
+    }
   }
-
+  
   private _subscribe() {
     this.unsub = subscribeEntityRegistry(this.hass!.connection, entries => {
       this.entities = entries;


### PR DESCRIPTION
Fixes #30 
## Description

This PR fixes a `NotFoundError` that occurs in `disconnectedCallback` on iOS devices (and potentially others).

The issue causes a `NotFoundError` in the logs **on every launch of the Home Assistant Companion App** (when rendering a dashboard with this card). This happens when the card is removed from the DOM (likely during initial setup/teardown cycles or `mod-card` wrapper initialization). There is no visible crash, but the log error is persistent.

## Changes

Updated `disconnectedCallback` to verify that `this.dialog` has a `parentNode` before attempting to remove it.

**Before:**

```javascript
disconnectedCallback() {
  super.disconnectedCallback();
  this.unsub && this.unsub();
  this.unsub = void 0;
  document.body.removeChild(this.dialog);
}
```

**After:**

```javascript
disconnectedCallback() {
  super.disconnectedCallback();
  this.unsub && this.unsub();
  this.unsub = void 0;
  if (this.dialog && this.dialog.parentNode) {
    this.dialog.parentNode.removeChild(this.dialog);
  }
}
```

## Verification

* **Verified on iOS Companion App** (Version 2026.1.1 / 2026.1652).
* **Environment**: Home Assistant Core 2026.1.2, Frontend 20260107.2.
* Confirmed that the `NotFoundError` no longer appears in the logs on app launch/rendering.
* Confirmed that navigating away from the dashboard no longer throws `NotFoundError` in the logs.